### PR TITLE
Cast all inputs of point to floats because #8

### DIFF
--- a/src/Geometries/Point.php
+++ b/src/Geometries/Point.php
@@ -7,8 +7,8 @@ class Point extends Geometry
 
     public function __construct($lat, $lng)
     {
-        $this->lat = $lat;
-        $this->lng = $lng;
+        $this->lat = (float)$lat;
+        $this->lng = (float)$lng;
     }
 
     public function getLat()
@@ -18,7 +18,7 @@ class Point extends Geometry
 
     public function setLat($lat)
     {
-        $this->lat = $lat;
+        $this->lat = (float)$lat;
     }
 
     public function getLng()
@@ -28,7 +28,7 @@ class Point extends Geometry
 
     public function setLng($lng)
     {
-        $this->lng = $lng;
+        $this->lng = (float)$lng;
     }
 
     public function toPair()
@@ -40,7 +40,7 @@ class Point extends Geometry
     {
         list($lng, $lat) = explode(' ', trim($pair));
 
-        return new static($lat, $lng);
+        return new static((float)$lat, (float)$lng);
     }
 
     public function toWKT()

--- a/tests/Geometries/PointTest.php
+++ b/tests/Geometries/PointTest.php
@@ -1,6 +1,5 @@
 <?php
 
-use Phaza\LaravelPostgis\Geometries\Geometry;
 use Phaza\LaravelPostgis\Geometries\Point;
 
 class PointTest extends BaseTestCase
@@ -21,10 +20,36 @@ class PointTest extends BaseTestCase
         $this->assertEquals('POINT(2 1)', $point->toWKT());
     }
 
-    public function testToString()
+    public function testGettersAndSetters()
     {
         $point = new Point(1, 2);
+        $this->assertSame(1.0, $point->getLat());
+        $this->assertSame(2.0, $point->getLng());
 
-        $this->assertEquals('2 1', (string)$point);
+        $point->setLat('3');
+        $point->setLng('4');
+
+        $this->assertSame(3.0, $point->getLat());
+        $this->assertSame(4.0, $point->getLng());
+    }
+
+    public function testPair()
+    {
+        $point = Point::fromPair('1.5 2');
+
+        $this->assertSame(1.5, $point->getLng());
+        $this->assertSame(2.0, $point->getLat());
+
+        $this->assertSame('1.5 2', $point->toPair());
+    }
+
+    public function testToString()
+    {
+        $point = Point::fromString('1.3 2');
+
+        $this->assertSame(1.3, $point->getLng());
+        $this->assertSame(2.0, $point->getLat());
+
+        $this->assertEquals('1.3 2', (string)$point);
     }
 }


### PR DESCRIPTION
This should be it for floats in the `Point` class.
I will take a look, if there's a similar problem with other geometries.