### PR TITLE
Allow the creation of generic geography type

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -6,9 +6,6 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * Add a point column on the table
      *
      * @param      $column
-     * @param null $srid
-     * @param int $dimensions
-     * @param bool $typmod
      * @return \Illuminate\Support\Fluent
      */
     public function point($column)
@@ -20,9 +17,6 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * Add a multipoint column on the table
      *
      * @param      $column
-     * @param null $srid
-     * @param int $dimensions
-     * @param bool $typmod
      * @return \Illuminate\Support\Fluent
      */
     public function multipoint($column)
@@ -34,9 +28,6 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * Add a polygon column on the table
      *
      * @param      $column
-     * @param null $srid
-     * @param int $dimensions
-     * @param bool $typmod
      * @return \Illuminate\Support\Fluent
      */
     public function polygon($column)
@@ -48,9 +39,6 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * Add a multipolygon column on the table
      *
      * @param      $column
-     * @param null $srid
-     * @param int $dimensions
-     * @param bool $typmod
      * @return \Illuminate\Support\Fluent
      */
     public function multipolygon($column)
@@ -62,9 +50,6 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * Add a linestring column on the table
      *
      * @param      $column
-     * @param null $srid
-     * @param int $dimensions
-     * @param bool $typmod
      * @return \Illuminate\Support\Fluent
      */
     public function linestring($column)
@@ -76,14 +61,22 @@ class Blueprint extends \Bosnadev\Database\Schema\Blueprint
      * Add a multilinestring column on the table
      *
      * @param      $column
-     * @param null $srid
-     * @param int $dimensions
-     * @param bool $typmod
      * @return \Illuminate\Support\Fluent
      */
     public function multilinestring($column)
     {
         return $this->addColumn('multilinestring', $column);
+    }
+
+    /**
+     * Add a geography column on the table
+     *
+     * @param   string  $column
+     * @return \Illuminate\Support\Fluent
+     */
+    public function geography($column)
+    {
+        return $this->addColumn('geography', $column);
     }
 
     /**

--- a/src/Schema/Grammars/PostgisGrammar.php
+++ b/src/Schema/Grammars/PostgisGrammar.php
@@ -9,8 +9,7 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to add a point geometry column
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param \Illuminate\Support\Fluent $column
      * @return string
      */
     public function typePoint(Fluent $column)
@@ -21,8 +20,7 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to add a point geometry column
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param \Illuminate\Support\Fluent $column
      * @return string
      */
     public function typeMultipoint(Fluent $column)
@@ -33,8 +31,7 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to add a polygon geometry column
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param \Illuminate\Support\Fluent $column
      * @return string
      */
     public function typePolygon(Fluent $column)
@@ -45,8 +42,7 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to add a multipolygon geometry column
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param \Illuminate\Support\Fluent $column
      * @return string
      */
     public function typeMultipolygon(Fluent $column)
@@ -57,8 +53,7 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to add a linestring geometry column
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param \Illuminate\Support\Fluent $column
      * @return string
      */
     public function typeLinestring(Fluent $column)
@@ -69,13 +64,23 @@ class PostgisGrammar extends PostgresGrammar
     /**
      * Adds a statement to add a multilinestring geometry column
      *
-     * @param Blueprint $blueprint
-     * @param Fluent $command
+     * @param \Illuminate\Support\Fluent $column
      * @return string
      */
     public function typeMultilinestring(Fluent $column)
     {
         return 'GEOGRAPHY(MULTILINESTRING, 4326)';
+    }
+
+    /**
+     * Adds a statement to add a linestring geometry column
+     *
+     * @param \Illuminate\Support\Fluent $column
+     * @return string
+     */
+    public function typeGeography(Fluent $column)
+    {
+        return 'GEOGRAPHY';
     }
 
     /**

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -61,6 +61,15 @@ class BlueprintTest extends BaseTestCase
         $this->blueprint->multilinestring('col');
     }
 
+    public function testGeography()
+    {
+        $this->blueprint
+            ->shouldReceive('addCommand')
+            ->with('geography', ['col', null, 2, true]);
+
+        $this->blueprint->geography('col');
+    }
+
     public function testGeometryCollection()
     {
         $this->blueprint

--- a/tests/Schema/Grammars/PostgisGrammarTest.php
+++ b/tests/Schema/Grammars/PostgisGrammarTest.php
@@ -67,6 +67,16 @@ class PostgisGrammarBaseTest extends BaseTestCase
         $this->assertContains('GEOGRAPHY(MULTIPOLYGON, 4326)', $statements[0]);
     }
 
+    public function testAddingGeography()
+    {
+        $blueprint = new Blueprint('test');
+        $blueprint->geography('foo');
+        $statements = $blueprint->toSql($this->getConnection(), $this->getGrammar());
+
+        $this->assertEquals(1, count($statements));
+        $this->assertContains('GEOGRAPHY', $statements[0]);
+    }
+
     public function testAddingGeometryCollection()
     {
         $blueprint = new Blueprint('test');


### PR DESCRIPTION
This can be useful as it can store any geog type such as point, polygon, etc. It allows for a great deal of flexibility w/o having to do database gymnastics to achieve the same sort of goal.

I also cleaned up a lot of docblocks as I came across them. Several of them had entries for parameters that weren't present in the method definition.