### PR TITLE
Allow for unspecified geometry in postgisFields

### DIFF
--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -1,12 +1,15 @@
 <?php namespace Phaza\LaravelPostgis\Eloquent;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Arr;
 use Phaza\LaravelPostgis\Exceptions\PostgisFieldsNotDefinedException;
 use Phaza\LaravelPostgis\Geometries\Geometry;
 use Phaza\LaravelPostgis\Geometries\GeometryInterface;
 
 trait PostgisTrait
 {
+
+    public $geometries = [];
     /**
      * Create a new Eloquent query builder for the model.
      *
@@ -22,17 +25,26 @@ trait PostgisTrait
     {
         foreach ($this->attributes as $key => &$value) {
             if ($value instanceof GeometryInterface) {
+                $this->geometries[$key] = $value; //Preserve the geometry objects prior to the insert
                 $value = $this->getConnection()->raw(sprintf("ST_GeogFromText('%s')", $value->toWKT()));
             }
         }
 
-        return parent::performInsert($query, $options);
+        $insert = parent::performInsert($query, $options);
+
+        foreach($this->geometries as $key => $value){
+            $this->attributes[$key] = $value; //Retrieve the geometry objects so they can be used in the model
+        }
+
+        return $insert; //Return the result of the parent insert
     }
 
     public function setRawAttributes(array $attributes, $sync = false)
     {
+        $pgfields = $this->getPostgisFields();
+
         foreach ($attributes as $attribute => &$value) {
-            if (in_array($attribute, $this->getPostgisFields()) && is_string($value) && strlen($value) >= 15) {
+            if (in_array($attribute, $pgfields) && is_string($value) && strlen($value) >= 15) {
                 $value = Geometry::fromWKB($value);
             }
         }
@@ -43,7 +55,9 @@ trait PostgisTrait
     public function getPostgisFields()
     {
         if (property_exists($this, 'postgisFields')) {
-            return $this->postgisFields;
+            return Arr::isAssoc($this->postgisFields) ? //Is the array associative?
+                array_keys($this->postgisFields) : //Returns just the keys to preserve compatibility with previous versions
+                $this->postgisFields; //Returns the non-associative array that doesn't define the geometry type.
         } else {
             throw new PostgisFieldsNotDefinedException(__CLASS__ . ' has to define $postgisFields');
         }

--- a/src/Eloquent/PostgisTrait.php
+++ b/src/Eloquent/PostgisTrait.php
@@ -31,10 +31,8 @@ trait PostgisTrait
 
     public function setRawAttributes(array $attributes, $sync = false)
     {
-        $pgfields = array_keys($this->getPostgisFields());
-
         foreach ($attributes as $attribute => &$value) {
-            if (in_array($attribute, $pgfields) && is_string($value) && strlen($value) >= 15) {
+            if (in_array($attribute, $this->getPostgisFields()) && is_string($value) && strlen($value) >= 15) {
                 $value = Geometry::fromWKB($value);
             }
         }


### PR DESCRIPTION
performInsert() will no longer leave a newly created geometry field as an Expression type in a model's attributes

getPostgisFields will now return non-associative postgisFields array and associative arrays the same so it is no longer necessary to specify geometry type
      in a model. Note: cannot mix and match associative and non-associative in the same array.
