### PR TITLE
Use singleton method

### DIFF
--- a/src/DatabaseServiceProvider.php
+++ b/src/DatabaseServiceProvider.php
@@ -20,14 +20,14 @@ class DatabaseServiceProvider extends PostgresDatabaseServiceProvider
         // The connection factory is used to create the actual connection instances on
         // the database. We will inject the factory into the manager so that it may
         // make the connections while they are actually needed and not of before.
-        $this->app->bindShared('db.factory', function ($app) {
+        $this->app->singleton('db.factory', function ($app) {
             return new ConnectionFactory($app);
         });
 
         // The database manager is used to resolve various connections, since multiple
         // connections might be managed. It also implements the connection resolver
         // interface which may be used by other components requiring connections.
-        $this->app->bindShared('db', function ($app) {
+        $this->app->singleton('db', function ($app) {
             return new DatabaseManager($app, $app['db.factory']);
         });
     }


### PR DESCRIPTION
The `bindShared()` method was deprecated in Laravel 5.1 and removed in 5.2: https://laravel.com/docs/5.2/upgrade#upgrade-5.1.0

The `singleton()` method should be used instead.

This should fix [issue#28](https://github.com/phaza/laravel-postgis/issues/28)