### PR TITLE
Make createConnection compatible with framework v5.2.7

### DIFF
--- a/src/Connectors/ConnectionFactory.php
+++ b/src/Connectors/ConnectionFactory.php
@@ -1,19 +1,18 @@
 <?php namespace Phaza\LaravelPostgis\Connectors;
 
-use PDO;
 use Phaza\LaravelPostgis\PostgisConnection;
 
 class ConnectionFactory extends \Bosnadev\Database\Connectors\ConnectionFactory
 {
     /**
      * @param string $driver
-     * @param PDO $connection
+     * @param $connection
      * @param string $database
      * @param string $prefix
      * @param array $config
      * @return mixed|PostgisConnection
      */
-    protected function createConnection($driver, PDO $connection, $database, $prefix = '', array $config = [])
+    protected function createConnection($driver, $connection, $database, $prefix = '', array $config = [])
     {
         if ($this->container->bound($key = "db.connection.{$driver}")) {
             return $this->container->make($key, [$connection, $database, $prefix, $config]);


### PR DESCRIPTION
Framework v5.2.7 refactored the code so that `createConnection()` only accepts a simple `$connection` variable, so we need our method to as well, otherwise we get a compatibility error.

We also need the `bosnadev\database` package to fix their method as well.